### PR TITLE
Add option to use xcodebuild instead of xctool.

### DIFF
--- a/bin/objc
+++ b/bin/objc
@@ -2,12 +2,13 @@
 
 path = __FILE__
 $:.unshift(File.join(File.dirname(File.expand_path(path)), '..', 'lib'))
-require 'objc'
 
-if ARGV.length == 1
-  Objc::Test.with(ARGV[0])
-else
-  puts %{
+require 'objc'
+require 'optparse'
+
+def usage
+  <<-TXT.sub(/^\s+/, '')
+    Usage: objc [options] FILE_PREFIX
 
     The `objc` binary requires that you provide a file prefix so that it is
     able to find the: header file; source file; and test file.
@@ -15,5 +16,34 @@ else
     $ objc Anagram
 
     This will find the following: Anagram.h; Anagram.m; and AnagramTest.m
-}
+  TXT
+end
+
+options = { runner: :xctool }
+
+OptionParser.new do |opts|
+  opts.banner = usage
+  opts.separator ""
+  opts.separator "Specific options:"
+
+  opts.on("-x", "--xcodebuild", "Use xcodebuild") do
+    options[:runner] = :xcodebuild
+  end
+
+  opts.on_tail("-h", "--help", "Show this message") do
+    puts opts
+    exit
+  end
+
+  opts.on_tail("--version", "Show version") do
+    puts Objc::VERSION
+    exit
+  end
+end.parse!
+
+if ARGV.count == 1
+  Objc::Test.with(ARGV[0], runner: options[:runner])
+else
+  system("objc --help")
+  exit
 end

--- a/lib/objc.rb
+++ b/lib/objc.rb
@@ -9,12 +9,12 @@ module Objc
   module Test
     extend self
 
-    def with(filePrefix)
+    def with(filePrefix, runner: :xctool)
       puts "Looking for all files with prefix: #{filePrefix}"
 
       files = SourceFiles.new(filePrefix)
 
-      project = XcodeProject.new
+      project = XcodeProject.new(runner)
       project.install!
       project.add(files)
       project.execute!

--- a/lib/objc/version.rb
+++ b/lib/objc/version.rb
@@ -1,3 +1,3 @@
 module Objc
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/lib/objc/xcode_project.rb
+++ b/lib/objc/xcode_project.rb
@@ -1,6 +1,11 @@
 module Objc
   module Test
     class XcodeProject
+      attr_reader :runner
+
+      def initialize(runner)
+        @runner = runner
+      end
 
       def install!
         clean
@@ -74,8 +79,16 @@ module Objc
         'test-suite'
       end
 
+      def use_xcodebuild?
+        runner == :xcodebuild
+      end
+
       def xctool_command
-        "xctool -project #{project_path} -scheme IgnoreThisTarget test"
+        if use_xcodebuild?
+          "xcodebuild -project #{project_path} -scheme IgnoreThisTarget test | xcpretty"
+        else
+          "xctool -project #{project_path} -scheme IgnoreThisTarget test"
+        end
       end
     end
   end

--- a/objc.gemspec
+++ b/objc.gemspec
@@ -21,8 +21,9 @@ execution of a test suite without the hassle of managing an Xcode Project File}
   spec.require_paths = ["lib"]
 
   spec.add_dependency "xcoder", "~> 0.1.15"
+  spec.add_dependency "xcpretty", "~> 0.2.6"
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "~> 11.2"
 
 end


### PR DESCRIPTION
Hi @burtlo 👋 

I came across your gem while working on the [Exercism.io Objective-C track](http://exercism.io/languages/objective-c/tests).

Unfortunately xctool doesn't support the latest version of Xcode, so I made this modification to allow using `xcodebuild` instead.

Let me know if you think this would be useful in the published gem.

Sample output using Xcode 8.3.1 (some noise removed):

```
% objc HelloWorld

Looking for all files with prefix: HelloWorld
Loading files into ExercismTestFixture (Project) at /var/folders/c1/855g8kxn12vcy4g6k97c_cc80000gn/T/ExercismTestFixture/ExercismTestFixture.xcodeproj
ERROR: Unexpected action: test
```

```
% objc HelloWorld -h
Usage: objc [options] FILE_PREFIX

    The `objc` binary requires that you provide a file prefix so that it is
    able to find the: header file; source file; and test file.

    $ objc Anagram

    This will find the following: Anagram.h; Anagram.m; and AnagramTest.m

Specific options:
    -x, --xcodebuild                 Use xcodebuild
    -h, --help                       Show this message
        --version                    Show version
```

```
% objc HelloWorld -x
▸ Building ExercismTestFixture/IgnoreThisTarget [Debug]
▸ Check Dependencies
▸ Processing IgnoreThisTarget-Info.plist
▸ Touching IgnoreThisTarget.app
▸ Building ExercismTestFixture/test-suite [Debug]
▸ Check Dependencies
▸ Test Succeeded
All tests
Test Suite test-suite.xctest started
HelloWorldTest
    ✓ testNoName (0.086 seconds)
    ✓ testOtherSampleName (0.001 seconds)
    ✓ testSampleName (0.000 seconds)


         Executed 3 tests, with 0 failures (0 unexpected) in 0.087 (0.088) seconds
```